### PR TITLE
Fixed Tanglekit TKIf and TKSwitch classes' element display behavior

### DIFF
--- a/TangleKit/TangleKit.js
+++ b/TangleKit/TangleKit.js
@@ -25,8 +25,9 @@ Tangle.classes.TKIf = {
     },
     
     update: function (element, value) {
-        if (this.isInverted) { value = !value; }
-        element.style.display = !value ? "none" : "inline";   // todo, block or inline?
+        if (this.isInverted) { value = !value; };
+        if (value) { element.style.removeProperty('display'); } 
+		else { element.style.display = "none" };
     }
 };
 
@@ -43,7 +44,8 @@ Tangle.classes.TKSwitch = {
 
     update: function (element, value) {
         element.getChildren().each( function (child, index) {
-            child.style.display = (index != value) ? "none" : "inline";
+            if (index != value) { child.style.display = 'none'; } 
+			else { child.style.removeProperty('display'); }
         });
     }
 };


### PR DESCRIPTION
When `TKIf` and `TKSwitch` would hide and show elements, they put the `display: none` property on them but reverted to `display: inline` regardless of what the element was.

Now it just removes the element style property so that the element reverts to its natural display state rather than being forced into `inline`

Hope it helps
