### PR TITLE
Add the 'none' display format

### DIFF
--- a/Tangle.js
+++ b/Tangle.js
@@ -387,4 +387,5 @@ Tangle.classes = {};
 Tangle.formats = {};
 
 Tangle.formats["default"] = function (value) { return "" + value; };
+Tangle.formats["none"] = function (value) { return ""; };
 


### PR DESCRIPTION
Adding this by default allows it to be easy to make elements which
manipulate a value without exposing the underlying value.
