### PR TITLE
Tangle elements changing data- attributes based on changing values

### DIFF
--- a/TangleKit/TangleKit.js
+++ b/TangleKit/TangleKit.js
@@ -217,12 +217,24 @@ Tangle.classes.TKAdjustableNumber = {
     },
     
     touchDidMove: function (touches) {
-        var value = this.valueAtMouseDown + touches.translation.x / 5 * this.step;
+	//lets Tangle respond WITHIN drag duration to new attribute settings
+        var attributes = this.element.attributes;
+        var regexp = /^data-[\w\-]+$/;
+        for (var i = 0, length = attributes.length; i < length; i++) {
+
+            var attr = attributes[i];
+            var attrName = attr.name;
+            if (!attrName || !regexp.test(attrName)) { continue; }
+            
+            this[attrName.substr(5)] = attr.value;
+        }
+
+	var value = this.valueAtMouseDown + touches.translation.x / 5 * this.step;
         value = ((value / this.step).round() * this.step).limit(this.min, this.max);
         this.tangle.setValue(this.variable, value);
         this.updateHelp();
     },
-    
+
     touchDidGoUp: function (touches) {
         this.isDragging = false;
         isAnyAdjustableNumberDragging = false;


### PR DESCRIPTION
Hi, we're big fans of Tangle @ my company, but we ran into an issue when trying to limit one element based on another.  Changing the data-max variable did nothing, as Tangle takes the attributes at initialization and then never looks at them again.  

So I took some code from your getOptionsForElement function and dropped it into the touchDidMove function of the TKAdjustableNumber class.  I'm still something of a js newb, so I wasn't sure how to just call the gOFE function from there.  

But this was how I fixed it, allowing data- attributes to change after inititialization (and even within one click, -format being the main application that I can think of).

Thanks for a great library!
