### PR TITLE
Adds a scale to TKAdjustableNumber to adjust the rate at which drag events change the value

### DIFF
--- a/TangleKit/TangleKit.js
+++ b/TangleKit/TangleKit.js
@@ -146,6 +146,7 @@ Tangle.classes.TKAdjustableNumber = {
         this.max = (options.max !== undefined) ? parseFloat(options.max) : 1e100;
         this.step = (options.step !== undefined) ? parseFloat(options.step) : 1;
         this.scale = (options.scale !== undefined) ? parseFloat(options.scale) : 1/5;
+        this.digits = (""+this.step).split('.')[1].length;
         
         this.initializeHover();
         this.initializeHelp();
@@ -220,8 +221,8 @@ Tangle.classes.TKAdjustableNumber = {
     
     touchDidMove: function (touches) {
         var value = this.valueAtMouseDown + touches.translation.x * this.scale * this.step;
-        value = ((value / this.step).round() * this.step).limit(this.min, this.max);
-        this.tangle.setValue(this.variable, value);
+        value = ((value / this.step).round() * this.step).limit(this.min, this.max).toFixed(this.digits);
+        this.tangle.setValue(this.variable, parseFloat(value, 10));
         this.updateHelp();
     },
     

--- a/TangleKit/TangleKit.js
+++ b/TangleKit/TangleKit.js
@@ -131,6 +131,7 @@ Tangle.classes.TKNumberField = {
 //  Attributes:  data-min (optional): minimum value
 //               data-max (optional): maximum value
 //               data-step (optional): granularity of adjustment (can be fractional)
+//               data-scale (optional): rate of drag movements
 
 var isAnyAdjustableNumberDragging = false;  // hack for dragging one value over another one
 
@@ -144,6 +145,7 @@ Tangle.classes.TKAdjustableNumber = {
         this.min = (options.min !== undefined) ? parseFloat(options.min) : 0;
         this.max = (options.max !== undefined) ? parseFloat(options.max) : 1e100;
         this.step = (options.step !== undefined) ? parseFloat(options.step) : 1;
+        this.scale = (options.scale !== undefined) ? parseFloat(options.scale) : 1/5;
         
         this.initializeHover();
         this.initializeHelp();
@@ -217,7 +219,7 @@ Tangle.classes.TKAdjustableNumber = {
     },
     
     touchDidMove: function (touches) {
-        var value = this.valueAtMouseDown + touches.translation.x / 5 * this.step;
+        var value = this.valueAtMouseDown + touches.translation.x * this.scale * this.step;
         value = ((value / this.step).round() * this.step).limit(this.min, this.max);
         this.tangle.setValue(this.variable, value);
         this.updateHelp();


### PR DESCRIPTION
Also, adds a .toFixed call on the number so that it only matches the number of digits the step size has (js rounding errors were creating things like 1.2000000001 when step size is 0.2)
